### PR TITLE
python3-labgrid: exporter: allow passing args to systemd ExecStart

### DIFF
--- a/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
+++ b/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/labgrid/environment
-ExecStart=/usr/bin/python3 /usr/bin/labgrid-exporter -d -x ws://${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT}/ws /etc/labgrid/configuration.yaml
+ExecStart=/usr/bin/python3 /usr/bin/labgrid-exporter -d -x ws://${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT}/ws /etc/labgrid/configuration.yaml ${LABGRID_ARGS}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Allow configuring e.g. the exporter hostname from the environment file
by adding ${LABGRID_ARGS} to the ExecStart command line.