### PR TITLE
python*-pyserial: Add recipe for version 3.4.0.1

### DIFF
--- a/recipes-devtools/python/python-pyserial.inc
+++ b/recipes-devtools/python/python-pyserial.inc
@@ -1,0 +1,44 @@
+SUMMARY = "Serial Port Support for Python"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d476d94926db6e0008a5b3860d1f5c0d"
+
+inherit pypi
+
+PYPI_SRC_URI = "https://github.com/labgrid-project/pyserial/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "48d06795b8a9ed517a3fdd16f3d5efbf"
+SRC_URI[sha256sum] = "72bdb6863c4e12047e14be037f6b30e24901aa98af8ac7b63d6aab170db5790e"
+
+PACKAGES =+ "${PN}-java ${PN}-osx ${PN}-win32 ${PN}-tools"
+
+FILES_${PN}-java = " \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/*java* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/__pycache__/*java* \
+"
+
+FILES_${PN}-osx = " \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/tools/*osx* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/tools/__pycache__/*osx* \
+"
+
+FILES_${PN}-win32 = " \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/*serialcli* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/__pycache__/*serialcli* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/*win32* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/__pycache__/*win32* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/tools/miniterm* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/tools/__pycache__/miniterm* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/tools/*windows* \
+    ${PYTHON_SITEPACKAGES_DIR}/serial/tools/__pycache__/*windows* \
+"
+
+RDEPENDS_${PN} = "\
+    ${PYTHON_PN}-fcntl \
+    ${PYTHON_PN}-io \
+    ${PYTHON_PN}-logging \
+    ${PYTHON_PN}-netclient \
+    ${PYTHON_PN}-numbers \
+    ${PYTHON_PN}-shell \
+    ${PYTHON_PN}-stringold \
+    ${PYTHON_PN}-threading \
+"

--- a/recipes-devtools/python/python-pyserial_3.4.0.1.bb
+++ b/recipes-devtools/python/python-pyserial_3.4.0.1.bb
@@ -1,0 +1,4 @@
+inherit setuptools
+require python-pyserial.inc
+
+RDEPENDS_${PN} += "${PYTHON_PN}-argparse"

--- a/recipes-devtools/python/python3-pyserial_3.4.0.1.bb
+++ b/recipes-devtools/python/python3-pyserial_3.4.0.1.bb
@@ -1,0 +1,7 @@
+inherit setuptools3
+require python-pyserial.inc
+
+do_install_append() {
+    rm -f ${D}${bindir}/miniterm.py
+    rmdir ${D}${bindir}
+}


### PR DESCRIPTION
Add pyserial Labgrid's fork that contains important RFC2217 fixes.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>