### PR TITLE
Update to latest HEAD, package bumps, dunfell compat.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "sumo rocko thud warrior zeus"
+LAYERSERIES_COMPAT_labgrid = "sumo rocko thud warrior zeus dunfell"

--- a/recipes-devtools/python/python3-argh_0.26.1.bb
+++ b/recipes-devtools/python/python3-argh_0.26.1.bb
@@ -12,7 +12,7 @@ SRC_URI[sha256sum] = "06a7442cb9130fb8806fe336000fcf20edf1f2f8ad205e7b62cec11850
 
 S = "${WORKDIR}/argh-${PV}"
 
-inherit setuptools
+inherit setuptools3
 
 export BUILD_SYS
 export HOST_SYS

--- a/recipes-devtools/python/python3-autobahn_17.10.1.bb
+++ b/recipes-devtools/python/python3-autobahn_17.10.1.bb
@@ -1,5 +1,0 @@
-inherit setuptools3
-require python-autobahn.inc
-
-SRC_URI[md5sum] = "f8c8d74bf73644719b751e6fb11dc4a3"
-SRC_URI[sha256sum] = "8cf74132a18da149c5ea3dcbb5e055f6f4fe5a0238b33258d29e89bd276a8078"

--- a/recipes-devtools/python/python3-autobahn_19.11.1.bb
+++ b/recipes-devtools/python/python3-autobahn_19.11.1.bb
@@ -1,0 +1,5 @@
+inherit setuptools3
+require python-autobahn.inc
+
+SRC_URI[md5sum] = "472d965c75dba0f8cb5f3b9f9001ed1b"
+SRC_URI[sha256sum] = "201b9879b49c6e259d4126dbafe9e3c73807de0c242d50065fbebc62c6ccb181"

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -28,7 +28,7 @@ SRC_URI = " \
     file://environment \
     "
 
-SRCREV = "30c6cb61e6292f36847e80ec3e5f730ddc4bac72"
+SRCREV = "a73fb41dc56c1b07948d3cd9715aab2a252a0e0c"
 S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"

--- a/recipes-devtools/python/python3-txaio_2.8.2.bb
+++ b/recipes-devtools/python/python3-txaio_2.8.2.bb
@@ -1,5 +1,0 @@
-inherit setuptools3
-require python-txaio.inc
-
-SRC_URI[md5sum] = "a20e3431c95896a49fa3ffa84f77cde1"
-SRC_URI[sha256sum] = "484cd6c4cdd3f6081b87188f3b2b9a36e02fba6816e8256917c4f6571b567571"

--- a/recipes-devtools/python/python3-txaio_20.4.1.bb
+++ b/recipes-devtools/python/python3-txaio_20.4.1.bb
@@ -1,0 +1,5 @@
+inherit setuptools3
+require python-txaio.inc
+
+SRC_URI[md5sum] = "c998be8d5837218c809266c0fce94687"
+SRC_URI[sha256sum] = "17938f2bca4a9cabce61346758e482ca4e600160cbc28e861493eac74a19539d"

--- a/recipes-devtools/python/python3-watchdog_0.8.3.bb
+++ b/recipes-devtools/python/python3-watchdog_0.8.3.bb
@@ -14,7 +14,7 @@ SRC_URI[sha256sum] = "7e65882adb7746039b6f3876ee174952f8eaaa34491ba34333ddf1fe35
 
 S = "${WORKDIR}/watchdog-${PV}"
 
-inherit setuptools
+inherit setuptools3
 
 export BUILD_SYS
 export HOST_SYS


### PR DESCRIPTION
These changes were necessary to get labgrid-exporter to run on a dunfell based system.