### PR TITLE
conf/layer.conf: add gatesgarth to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "sumo rocko thud warrior zeus dunfell"
+LAYERSERIES_COMPAT_labgrid = "zeus dunfell gatesgarth"


### PR DESCRIPTION
Remove all poky codenames that are out of support now.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>