### PR TITLE
update to honister's new override style syntax

### DIFF
--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -33,7 +33,7 @@ jobs:
           bitbake-layers add-layer ../meta-openembedded/meta-python
           bitbake-layers add-layer ../meta-labgrid
           echo 'INHERIT += "rm_work"' >> conf/local.conf
-          echo 'DISTRO_FEATURES_remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
+          echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
           echo 'SSTATE_MIRRORS = "file://.* http://195.201.147.117/sstate-cache/PATH"' >> conf/local.conf
       - name: Build autobahn
         run: |

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ you have to follow at least the following steps:
 
 1. Add the `labgrid` package to your systems image recipe::
 
-    IMAGE_INSTALL_append = " python3-labgrid"
+    IMAGE_INSTALL:append = " python3-labgrid"
 
 2. Build the rootfs for your device::
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "zeus dunfell gatesgarth hardknott"
+LAYERSERIES_COMPAT_labgrid = "gatesgarth hardknott honister"

--- a/recipes-backport/python/python3-ansicolors_1.1.8.bb
+++ b/recipes-backport/python/python3-ansicolors_1.1.8.bb
@@ -13,7 +13,7 @@ SRC_URI += " \
 	file://run-ptest \
 "
 
-RDEPENDS_${PN}-ptest += " \
+RDEPENDS:${PN}-ptest += " \
 	${PYTHON_PN}-pytest \
 "
 

--- a/recipes-backport/python/python3-autobahn_20.7.1.bb
+++ b/recipes-backport/python/python3-autobahn_20.7.1.bb
@@ -8,7 +8,7 @@ SRC_URI[sha256sum] = "86bbce30cdd407137c57670993a8f9bfdfe3f8e994b889181d85e844d5
 
 inherit pypi setuptools3
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-twisted \
     ${PYTHON_PN}-zopeinterface \
     ${PYTHON_PN}-py-ubjson \

--- a/recipes-backport/python/python3-cbor2_5.1.2.bb
+++ b/recipes-backport/python/python3-cbor2_5.1.2.bb
@@ -13,7 +13,7 @@ SRC_URI += " \
         file://run-ptest \
 "
 
-RDEPENDS_${PN}-ptest += " \
+RDEPENDS:${PN}-ptest += " \
        ${PYTHON_PN}-pytest \
        ${PYTHON_PN}-unixadmin \
 "
@@ -23,7 +23,7 @@ do_install_ptest() {
         cp -rf ${S}/tests/* ${D}${PTEST_PATH}/tests/
 }
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-datetime \
 "
 

--- a/recipes-backport/python/python3-graphviz_0.14.1.bb
+++ b/recipes-backport/python/python3-graphviz_0.14.1.bb
@@ -10,7 +10,7 @@ inherit pypi setuptools3
 
 PYPI_PACKAGE_EXT = "zip"
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-logging \
 "
 

--- a/recipes-backport/python/python3-py-ubjson_0.16.1.bb
+++ b/recipes-backport/python/python3-py-ubjson_0.16.1.bb
@@ -7,7 +7,7 @@ SRC_URI[sha256sum] = "b9bfb8695a1c7e3632e800fb83c943bf67ed45ddd87cd0344851610c69
 
 inherit pypi setuptools3
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-numbers \
 "
 

--- a/recipes-backport/python/python3-snappy_0.5.4.bb
+++ b/recipes-backport/python/python3-snappy_0.5.4.bb
@@ -10,6 +10,6 @@ inherit pypi setuptools3
 
 PYPI_PACKAGE = "python-snappy"
 
-RDEPENDS_${PN} += "snappy"
+RDEPENDS:${PN} += "snappy"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-backport/python/python3-txaio_20.4.1.bb
+++ b/recipes-backport/python/python3-txaio_20.4.1.bb
@@ -7,7 +7,7 @@ SRC_URI[sha256sum] = "17938f2bca4a9cabce61346758e482ca4e600160cbc28e861493eac74a
 
 inherit pypi setuptools3
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-twisted \
 "
 

--- a/recipes-backport/python/python3-u-msgpack-python_2.7.0.bb
+++ b/recipes-backport/python/python3-u-msgpack-python_2.7.0.bb
@@ -12,7 +12,7 @@ SRC_URI += " \
         file://run-ptest \
 "
 
-RDEPENDS_${PN}-ptest += " \
+RDEPENDS:${PN}-ptest += " \
        ${PYTHON_PN}-pytest \
 "
 
@@ -20,7 +20,7 @@ do_install_ptest() {
        cp -f ${S}/test_umsgpack.py ${D}${PTEST_PATH}/
 }
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-datetime \
 "
 

--- a/recipes-backport/python/python3-xmodem_0.4.6.bb
+++ b/recipes-backport/python/python3-xmodem_0.4.6.bb
@@ -7,7 +7,7 @@ SRC_URI[sha256sum] = "089737298f5738eabc43f2519efdc80b402693768f16383f7013b9e6f8
 
 inherit pypi setuptools3
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-logging \
 "
 

--- a/recipes-devtools/python/python3-labgrid/configuration.yaml
+++ b/recipes-devtools/python/python3-labgrid/configuration.yaml
@@ -6,9 +6,9 @@
 ### BSP layer of you project. Create a python3-labgrid.bbappend file that adds this
 ### file to your build:
 ###
-###   FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+###   FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 ###
-###   SRC_URI_append := " file://configuration.yaml"
+###   SRC_URI:append := " file://configuration.yaml"
 ###
 ### ---
 ###

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/labgrid-project"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c0e9407a08421b8c72f578433434f0bd"
 
-RDEPENDS_${PN} = " \
+RDEPENDS:${PN} = " \
     coreutils \
     ser2net \
     libgpiod \
@@ -39,9 +39,9 @@ DEPENDS += "python3-pytest-runner-native"
 
 inherit setuptools3 systemd
 
-SYSTEMD_SERVICE_${PN} = "labgrid-exporter.service"
+SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
 
-do_install_append() {
+do_install:append() {
     install -d ${D}${sysconfdir}/labgrid
     install -m 0644 ${WORKDIR}/configuration.yaml ${D}${sysconfdir}/labgrid
     install -m 0644 ${WORKDIR}/environment ${D}${sysconfdir}/labgrid
@@ -49,4 +49,4 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/labgrid-exporter.service ${D}${systemd_system_unitdir}/
 }
 
-FILES_${PN} += "${sysconfdir} ${systemd_system_unitdir}"
+FILES:${PN} += "${sysconfdir} ${systemd_system_unitdir}"

--- a/recipes-devtools/python/python3-powerrelay_git.bb
+++ b/recipes-devtools/python/python3-powerrelay_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/prevas-dk/labgrid-powerrelay"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=20796caa814f193af92c180d146bb7ec"
 
-RDEPENDS_${PN} = " \
+RDEPENDS:${PN} = " \
     python3-click \
     python3-aiohttp \
     python3-trafaret \
@@ -25,12 +25,12 @@ DEPENDS += "${PYTHON_PN}-pytest-runner-native"
 
 inherit setuptools3 systemd
 
-SYSTEMD_SERVICE_${PN} = "labgrid-powerrelay.service"
+SYSTEMD_SERVICE:${PN} = "labgrid-powerrelay.service"
 
-do_install_append() {
+do_install:append() {
     rm -rf "${D}${datadir}"
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/labgrid-powerrelay.service ${D}${systemd_system_unitdir}/
 }
 
-FILES_${PN} += "${systemd_system_unitdir}"
+FILES:${PN} += "${systemd_system_unitdir}"

--- a/recipes-devtools/python/python3-pyserial_3.4.0.1.bb
+++ b/recipes-devtools/python/python3-pyserial_3.4.0.1.bb
@@ -9,24 +9,24 @@ PYPI_SRC_URI = "https://github.com/labgrid-project/pyserial/releases/download/v$
 SRC_URI[md5sum] = "48d06795b8a9ed517a3fdd16f3d5efbf"
 SRC_URI[sha256sum] = "72bdb6863c4e12047e14be037f6b30e24901aa98af8ac7b63d6aab170db5790e"
 
-do_install_append() {
+do_install:append() {
     rm -f ${D}${bindir}/miniterm.py
     rmdir ${D}${bindir}
 }
 
 PACKAGES =+ "${PN}-java ${PN}-osx ${PN}-win32 ${PN}-tools"
 
-FILES_${PN}-java = " \
+FILES:${PN}-java = " \
     ${PYTHON_SITEPACKAGES_DIR}/serial/*java* \
     ${PYTHON_SITEPACKAGES_DIR}/serial/__pycache__/*java* \
 "
 
-FILES_${PN}-osx = " \
+FILES:${PN}-osx = " \
     ${PYTHON_SITEPACKAGES_DIR}/serial/tools/*osx* \
     ${PYTHON_SITEPACKAGES_DIR}/serial/tools/__pycache__/*osx* \
 "
 
-FILES_${PN}-win32 = " \
+FILES:${PN}-win32 = " \
     ${PYTHON_SITEPACKAGES_DIR}/serial/*serialcli* \
     ${PYTHON_SITEPACKAGES_DIR}/serial/__pycache__/*serialcli* \
     ${PYTHON_SITEPACKAGES_DIR}/serial/*win32* \
@@ -37,7 +37,7 @@ FILES_${PN}-win32 = " \
     ${PYTHON_SITEPACKAGES_DIR}/serial/tools/__pycache__/*windows* \
 "
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-fcntl \
     ${PYTHON_PN}-io \
     ${PYTHON_PN}-logging \


### PR DESCRIPTION
Done with conversion script:

  scripts/contrib/convert-overrides.py meta-labgrid

Update layer compatibility to support honister.

Note: New override-style syntax is supported by the latest version of poky gatesgarth and hardknott. Thus compatibility should actually be given.
