### PR TITLE
python3-labgrid: update labgrid to latest version

### DIFF
--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -31,7 +31,7 @@ SRC_URI = " \
     file://environment \
     "
 
-SRCREV = "0c5a45daf973805d703a2c61aee8789d83358a85"
+SRCREV = "3fe80b05ce77c67b8ea69870e7d2e96d1a498d93"
 S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"


### PR DESCRIPTION
Since the v0.4.0 release already misses a bunch of new commits we
directly take the latest version of 2021-10-28.

Signed-off-by: Holger Assmann <h.assmann@pengutronix.de>