### PR TITLE
fix override syntax

### DIFF
--- a/recipes-devtools/python/python3-janus_0.6.1.bb
+++ b/recipes-devtools/python/python3-janus_0.6.1.bb
@@ -7,4 +7,4 @@ SRC_URI[sha256sum] = "4712e0ef75711fe5947c2db855bc96221a9a03641b52e5ae8e25c2b705
 
 inherit pypi setuptools3
 
-RDEPENDS_${PN} += "python3-asyncio python3-core python3-threading"
+RDEPENDS:${PN} += "python3-asyncio python3-core python3-threading"

--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/linux-automation/lxa-iobus"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=0674f4b6076ccd96a8b400a746f71dd3"
 
-RDEPENDS_${PN} = " \
+RDEPENDS:${PN} = " \
     python3-aiohttp \
     python3-aiohttp-json-rpc \
     python3-can \
@@ -32,4 +32,4 @@ do_install:append() {
 
 }
 
-FILES_${PN} += "${libdir}"
+FILES:${PN} += "${libdir}"

--- a/recipes-devtools/python/python3-usbmuxctl_git.bb
+++ b/recipes-devtools/python/python3-usbmuxctl_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/linux-automation/usbmuxctl"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-RDEPENDS_${PN} = " \
+RDEPENDS:${PN} = " \
     python3-pyusb \
     python3-termcolor \
 "
@@ -26,4 +26,4 @@ do_install:append() {
     install -D -m0644 ${WORKDIR}/99-usbmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbmux.rules
 }
 
-FILES_${PN} += "${sysconfdir}"
+FILES:${PN} += "${sysconfdir}"

--- a/recipes-devtools/python/python3-usbsdmux_git.bb
+++ b/recipes-devtools/python/python3-usbsdmux_git.bb
@@ -21,4 +21,4 @@ do_install:append() {
     install -D -m0644 ${WORKDIR}/99-usbsdmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbsdmux.rules
 }
 
-FILES_${PN} += "${sysconfdir}"
+FILES:${PN} += "${sysconfdir}"


### PR DESCRIPTION
The previous PR reintroduced some old style overrides again, so fix them with
the conversion script:

  scripts/contrib/convert-overrides.py meta-labgrid

Note: New override-style syntax is supported by latest version of poky
gatesgarth and hardknott. Thus compatiblitiy should actually be given.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>