### PR TITLE
lxa-iobus: fix systemd service

### DIFF
--- a/recipes-devtools/python/python3-lxa-iobus/lxa-iobus.service
+++ b/recipes-devtools/python/python3-lxa-iobus/lxa-iobus.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=LXA iobus Server
+After=network.target
 
 [Service]
 Type=simple
@@ -8,9 +9,7 @@ ExecStart=/usr/bin/lxa-iobus-server -l WARN --firmware-directory /var/cache/lxa-
 EnvironmentFile=/etc/lxaiobus/environment
 Environment="PYTHONUNBUFFERED=1"
 Restart=on-failure
-RestartForceExitStatus=100
 RestartSec=30
 
-
 [Install]
-WantedBy=network.target
+WantedBy=multi-user.target

--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -22,14 +22,15 @@ S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"
 
-inherit setuptools3
+inherit setuptools3 systemd
 
 do_install:append() {
     # CAN interface setup is handled by systemd service instead of this script
     rm -f ${D}${bindir}/lxa-iobus-can-setup
     install -D -m0644 ${WORKDIR}/environment ${D}${sysconfdir}/lxa-iobus/environment
-    install -D -m0644 ${S}/contrib/systemd/lxa-iobus.service ${D}${systemd_unitdir}/lxa-iobus.service
-
+    install -D -m0644 ${S}/contrib/systemd/lxa-iobus.service ${D}${systemd_system_unitdir}/lxa-iobus.service
 }
 
 FILES:${PN} += "${libdir}"
+
+SYSTEMD_SERVICE:${PN} = "lxa-iobus.service"


### PR DESCRIPTION
The service should be activated by the multi-user.target. Also, we need to
install it into the correct path and inherit systemd to enable the service by
default.