### PR TITLE
Add sispmctl Tool

### DIFF
--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Build tools
         run: |
           source poky/oe-init-build-env build
-          bitbake python3-pyserial
+          bitbake python3-pyserial sispmctl

--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Build tools
         run: |
           source poky/oe-init-build-env build
-          bitbake python3-pyserial python3-pyserial
+          bitbake python3-pyserial

--- a/recipes-devtools/sispmctl/sispmctl_4.9.bb
+++ b/recipes-devtools/sispmctl/sispmctl_4.9.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "Control Gembird SIS-PM programmable power outlet strips"
+HOMEPAGE = "http://sispmctl.sourceforge.net/"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+DEPENDS = "libusb"
+
+inherit autotools pkgconfig
+
+PACKAGECONFIG[web] = "--disable-webless,--enable-webless,"
+
+SRC_URI = "https://sourceforge.net/projects/sispmctl/files/sispmctl/sispmctl-${PV}/sispmctl-${PV}.tar.gz"
+
+SRC_URI[sha256sum] = "6a9ec7125e8c01bb45d4a3b56f07fb41fc437020c8dcd8c0f29ebb98dc55a647"


### PR DESCRIPTION
sispmctl is a small commandline-tool to control Gembird SIS-PM programmable power outlet strips. labgrid uses it in its [SiSPMPowerDriver](https://labgrid.readthedocs.io/en/latest/configuration.html#sispmpowerdriver).
