### PR TITLE
Use https instead of git protocol in github.com SRC_URIs

### DIFF
--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -25,7 +25,7 @@ RDEPENDS:${PN} = " \
 "
 
 SRC_URI = " \
-    git://github.com/labgrid-project/labgrid.git;branch=master \
+    git://github.com/labgrid-project/labgrid.git;protocol=https;branch=master \
     file://configuration.yaml \
     file://labgrid-exporter.service \
     file://environment \

--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -11,7 +11,7 @@ RDEPENDS:${PN} = " \
 "
 
 SRC_URI = " \
-    git://github.com/linux-automation/lxa-iobus.git;branch=master \
+    git://github.com/linux-automation/lxa-iobus.git;protocol=https;branch=master \
     file://environment \
     "
 

--- a/recipes-devtools/python/python3-usbmuxctl_git.bb
+++ b/recipes-devtools/python/python3-usbmuxctl_git.bb
@@ -9,7 +9,7 @@ RDEPENDS:${PN} = " \
 "
 
 SRC_URI = " \
-    git://github.com/linux-automation/usbmuxctl.git;branch=master \
+    git://github.com/linux-automation/usbmuxctl.git;protocol=https;branch=master \
     file://99-usbmux.rules \
     "
 

--- a/recipes-devtools/python/python3-usbsdmux_git.bb
+++ b/recipes-devtools/python/python3-usbsdmux_git.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = " \
-    git://github.com/linux-automation/usbsdmux.git;branch=master \
+    git://github.com/linux-automation/usbsdmux.git;protocol=https;branch=master \
     file://99-usbsdmux.rules \
     "
 


### PR DESCRIPTION
Fixes these warnings for python3-labgrid/python3-lxa-iobus/python3-usbmuxctl/python3-usbsdmux in `do_fetch`:
`URL: git://github.com/<name>/<project>.git;branch=master uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url.`