### PR TITLE
Kirkstone release support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "gatesgarth hardknott honister"
+LAYERSERIES_COMPAT_labgrid = "gatesgarth hardknott honister kirkstone"

--- a/recipes-backport/python/python3-xmodem_0.4.6.bb
+++ b/recipes-backport/python/python3-xmodem_0.4.6.bb
@@ -12,3 +12,11 @@ RDEPENDS:${PN} += " \
 "
 
 BBCLASSEXTEND = "native nativesdk"
+
+do_install:append() {
+    # Move the documentation files to the expected location so they are
+    # packaged in the *-docs package.
+    mkdir -p ${D}${docdir}/
+    mv ${D}/usr/doc/* ${D}${docdir}/
+    rmdir ${D}/usr/doc
+}

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Embedded systems control library for development, testing and installation"
 HOMEPAGE = "https://github.com/labgrid-project"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c0e9407a08421b8c72f578433434f0bd"
 
 RDEPENDS:${PN} = " \

--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -15,8 +15,8 @@ SRC_URI = " \
     file://environment \
     "
 
-PV = "0.3+git${SRCPV}"
-SRCREV = "0261687d428171ed134399b66506ce7958bcddca"
+PV = "0.4.2+git${SRCPV}"
+SRCREV = "246063a2043c4d3ca357ec1c7dbea8623b9d9775"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/python/python3-pyserial_3.4.0.1.bb
+++ b/recipes-devtools/python/python3-pyserial_3.4.0.1.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Serial Port Support for Python"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d476d94926db6e0008a5b3860d1f5c0d"
 
 inherit pypi setuptools3

--- a/recipes-devtools/python/python3-usbmuxctl_git.bb
+++ b/recipes-devtools/python/python3-usbmuxctl_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Control software for Linux Automation GmbH USB-Mux that enables automated testing of embedded USB devices."
 HOMEPAGE = "https://github.com/linux-automation/usbmuxctl"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 RDEPENDS:${PN} = " \

--- a/recipes-devtools/python/python3-usbsdmux_git.bb
+++ b/recipes-devtools/python/python3-usbsdmux_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Control software for usb-sd-mux that switches a SD-Card between a Device Under Test (DUT) and a host PC."
 HOMEPAGE = "https://github.com/linux-automation/usbsdmux"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = " \

--- a/recipes-devtools/sispmctl/sispmctl_4.9.bb
+++ b/recipes-devtools/sispmctl/sispmctl_4.9.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Control Gembird SIS-PM programmable power outlet strips"
 HOMEPAGE = "http://sispmctl.sourceforge.net/"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 DEPENDS = "libusb"
 


### PR DESCRIPTION
Some changes to support the new kirkstone release.

- Change license identifiers to SPDX
- Make QA happy by not installing unpackaged documentation for python3-xmodem
- Upgrade lxa-iobus to a revision that has a [typo-fix](https://github.com/linux-automation/lxa-iobus/pull/32) in setup.cfg. That now results in the package not being buildable. This fix is not yet in master.
- Add kirkstone to the supported releases.

TODO before merging:

- [x] Wait for the lxa-iobus patch to land in master