### PR TITLE
python3-labgrid: disable debug output by default

### DIFF
--- a/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
+++ b/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/labgrid/environment
-ExecStart=/usr/bin/python3 /usr/bin/labgrid-exporter -d -x ws://${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT}/ws /etc/labgrid/configuration.yaml
+ExecStart=/usr/bin/python3 /usr/bin/labgrid-exporter -x ws://${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT}/ws /etc/labgrid/configuration.yaml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Running the exporter with debug enabled produces large amounts of log output,
which usually not needed. So disable debug mode.