### PR TITLE
Update labgrid/lxa-iobus/usbsdmux to most recent git versions

### DIFF
--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -31,13 +31,13 @@ SRC_URI = " \
     file://environment \
     "
 
-SRCREV = "2437f0f3bc09f24a6af660e4ee26c1141184ce9f"
+SRCREV = "b6fee448c41771fc5fee6c41fd2d6f4904549f19"
 S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"
 DEPENDS += "python3-pytest-runner-native"
 
-inherit setuptools3 systemd
+inherit python_setuptools_build_meta systemd
 
 SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
 

--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
     "
 
 PV = "0.4.2+git${SRCPV}"
-SRCREV = "246063a2043c4d3ca357ec1c7dbea8623b9d9775"
+SRCREV = "af8ff293e9867dc4444ee354c06c7f8bcac410a7"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/python/python3-usbsdmux_git.bb
+++ b/recipes-devtools/python/python3-usbsdmux_git.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
     "
 
 PV = "0.2.1+git${SRCPV}"
-SRCREV = "e4f3eda61c0c2617dd92ebf49d3f4539a2d0cbd6"
+SRCREV = "c3eea7d86e8d0e9a43e36e55e7a175aa7736b8ea"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Changes:

- `python3-labgrid` new features etc. and packages are now built using `pyproject.yaml`
- `python3-lxa-iobus` now exposes individual node info via REST and allows CORS requests.
- `python3-usbsdmux` some code cleanups.

Testing was done using the langdale release.