### PR TITLE
python3-labgrid: update to current master

### DIFF
--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -31,7 +31,7 @@ SRC_URI = " \
     file://environment \
     "
 
-SRCREV = "b6fee448c41771fc5fee6c41fd2d6f4904549f19"
+SRCREV = "91b710457311db7b7236b65cbb704166d6cf2f27"
 S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"


### PR DESCRIPTION
This is required to support the new authentication method used by recent coordinators.