### PR TITLE
layer.conf: remove kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "kirkstone langdale mickledore"
+LAYERSERIES_COMPAT_labgrid = "langdale mickledore"


### PR DESCRIPTION
Since labgrid switched to pyproject.toml and complete support is not available in kirkstone, remove it from the compatible layers list.

Closes https://github.com/labgrid-project/meta-labgrid/issues/33