### PR TITLE
labgrid: bump to 23.0.2

### DIFF
--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -31,7 +31,7 @@ SRC_URI = " \
     file://environment \
     "
 
-SRCREV = "5111f348d1be459f40192b183fda6daa095d2624"
+SRCREV = "ba15037ff7fb2cd0748aa404c6cf6dcff6c3b143"
 S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"


### PR DESCRIPTION
Update to latest stable release [23.0.2](https://github.com/labgrid-project/labgrid/releases/tag/v23.0.2).