### PR TITLE
Bump Recipe Versions

### DIFF
--- a/recipes-devtools/python/python3-janus_1.0.0.bb
+++ b/recipes-devtools/python/python3-janus_1.0.0.bb
@@ -3,8 +3,8 @@ HOMEPAGE = "https://pypi.org/project/janus/"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=23878c357ebb4c8ce1109be365043349"
 
-SRC_URI[sha256sum] = "4712e0ef75711fe5947c2db855bc96221a9a03641b52e5ae8e25c2b705dd1d0c"
+SRC_URI[sha256sum] = "df976f2cdcfb034b147a2d51edfc34ff6bfb12d4e2643d3ad0e10de058cb1612"
 
-inherit pypi setuptools3
+inherit python_setuptools_build_meta pypi
 
 RDEPENDS:${PN} += "python3-asyncio python3-core python3-threading"

--- a/recipes-devtools/python/python3-powerrelay_git.bb
+++ b/recipes-devtools/python/python3-powerrelay_git.bb
@@ -17,7 +17,7 @@ SRC_URI = " \
     git://github.com/prevas-dk/labgrid-powerrelay.git;protocol=https;branch=master \
     file://labgrid-powerrelay.service \
     "
-SRCREV = "bf5d2e11e0f594757d3d97a6a9f38480713aaace"
+SRCREV = "41c030f09495f67e5573b6f0d7411fef71d92e9e"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/python/python3-usbmuxctl_0.1.3.bb
+++ b/recipes-devtools/python/python3-usbmuxctl_0.1.3.bb
@@ -3,24 +3,20 @@ HOMEPAGE = "https://github.com/linux-automation/usbmuxctl"
 LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
+SRC_URI[sha256sum] = "b7a9c7bf0645e0d2026fc63307a6724c24be6a33961f0f65cc313be7c8d45feb"
+
+SRC_URI += " \
+    file://99-usbmux.rules \
+    "
+
+DEPENDS += "python3-setuptools-scm-native"
+
 RDEPENDS:${PN} = " \
     python3-pyusb \
     python3-termcolor \
 "
 
-SRC_URI = " \
-    git://github.com/linux-automation/usbmuxctl.git;protocol=https;branch=master \
-    file://99-usbmux.rules \
-    "
-
-PV = "0.1.1+git${SRCPV}"
-SRCREV = "096905f9de6df1f396582b8de1faef31d43d1a81"
-
-S = "${WORKDIR}/git"
-
-DEPENDS += "python3-setuptools-scm-native"
-
-inherit setuptools3
+inherit setuptools3 pypi
 
 do_install:append() {
     install -D -m0644 ${WORKDIR}/99-usbmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbmux.rules

--- a/recipes-devtools/sispmctl/sispmctl_4.11.bb
+++ b/recipes-devtools/sispmctl/sispmctl_4.11.bb
@@ -10,4 +10,4 @@ PACKAGECONFIG[web] = "--disable-webless,--enable-webless,"
 
 SRC_URI = "https://sourceforge.net/projects/sispmctl/files/sispmctl/sispmctl-${PV}/sispmctl-${PV}.tar.gz"
 
-SRC_URI[sha256sum] = "6a9ec7125e8c01bb45d4a3b56f07fb41fc437020c8dcd8c0f29ebb98dc55a647"
+SRC_URI[sha256sum] = "74b94a3710046b15070c7311f0cacb81554c86b4227719cc2733cb96c7052578"


### PR DESCRIPTION
- python3-janus: version bump 0.6.1 -> 1.0.0
- python3-powerrelay: version bump bf5d2e1 -> 41c030f
- python3-usbmuxctl: install from pypi, version bump 096905f -> 0.1.3
- sispmctl: version bump 4.9 -> 4.11

Build-tested only.