### PR TITLE
layer.conf: add 'nanbield' to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "langdale mickledore"
+LAYERSERIES_COMPAT_labgrid = "mickledore nanbield"


### PR DESCRIPTION
poky/oe-core just released 'nanbield' and thus removed 'mickledore' compatibility.

While at it, remove 'langdale' which is out of support.