### PR TITLE
python3-aiohttp-json-rpc: add recipe to satisfy lxa-iobus dependency

### DIFF
--- a/recipes-devtools/python/python3-aiohttp-json-rpc_0.13.3.bb
+++ b/recipes-devtools/python/python3-aiohttp-json-rpc_0.13.3.bb
@@ -1,0 +1,12 @@
+SUMMARY = "json rpc for asyncio"
+HOMEPAGE = "https://github.com/pengutronix/aiohttp-json-rpc/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=500d879cf7db09f86dc29654f8488e30"
+
+RDEPENDS:${PN} = " \
+    ${PYTHON_PN}-aiohttp \
+"
+
+inherit pypi setuptools3
+
+SRC_URI[sha256sum] = "6237a104478c22c6ef96c7227a01d6832597b414e4b79a52d85593356a169e99"


### PR DESCRIPTION
The `python3-lxa-iobus_git.bb` recipe depends on `python3-aiohttp-json-rpc`:

https://github.com/labgrid-project/meta-labgrid/blob/07346a8795c958dbd59f7c8c83dd30e3924b4f59/recipes-devtools/python/python3-lxa-iobus_git.bb#L8

This dependency is not satisfied by any of the common layers.

We work around this in [`meta-lxatac` ](https://github.com/linux-automation/meta-lxatac/) by including our own [`python3-aiohttp-json-rpc`](https://github.com/linux-automation/meta-lxatac/blob/55bc6f10f4ec8db4be6e89a708345ff7aa710227/meta-lxatac-software/recipes-python/python3-aiohttp-json-rpc/python3-aiohttp-json-rpc_0.12.1.bb#L1-L13) recipe, but `meta-labgrid` would be a better place to solve this.

Include the recipe here and while at it also update it to the most recent release.

Fixes: #43