### PR TITLE
github/workflows: also test lxa-iobus, usbmuxctl and usbsdmux builds

### DIFF
--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -53,3 +53,7 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake python3-lxa-iobus
+      - name: Build usbmuxctl
+        run: |
+          source poky/oe-init-build-env build
+          bitbake python3-usbmuxctl

--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake python3-labgrid
-      - name: Build tools
+      - name: Build sispmctl
         run: |
           source poky/oe-init-build-env build
-          bitbake python3-pyserial sispmctl
+          bitbake sispmctl

--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -57,3 +57,7 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake python3-usbmuxctl
+      - name: Build usbsdmux
+        run: |
+          source poky/oe-init-build-env build
+          bitbake python3-usbsdmux

--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -49,3 +49,7 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake sispmctl
+      - name: Build lxa-iobus
+        run: |
+          source poky/oe-init-build-env build
+          bitbake python3-lxa-iobus


### PR DESCRIPTION
These packages should be relatively lightweight when compared to the ones that are already built in the CI job, so adding them should not do much harm.

~~This draft is based on #44 because it is needed to build `lxa-iobus` and I want to see it succeed once. Once the first CI run is complete I will rebase this PR on top of master without #44 in it and un-draft it.~~

With #44 applied the [build works just fine](https://github.com/labgrid-project/meta-labgrid/actions/runs/6979487403) and is only about 3min slower than before. That admittedly sounds like a lot but for a 2h45min run is within the margin of error.