### PR TITLE
python3-usbsdmux: update package version to 0.3.0

### DIFF
--- a/recipes-devtools/python/python3-usbsdmux_0.3.0.bb
+++ b/recipes-devtools/python/python3-usbsdmux_0.3.0.bb
@@ -8,8 +8,7 @@ SRC_URI = " \
     file://99-usbsdmux.rules \
     "
 
-PV = "0.2.1+git${SRCPV}"
-SRCREV = "c3eea7d86e8d0e9a43e36e55e7a175aa7736b8ea"
+SRCREV = "3eb689fac8b5560b56f92b531cbbab654676dae7"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Hi,

@SmithChart released a new version of the [USB-SD-Mux](https://github.com/linux-automation/usbsdmux/releases/tag/0.3.0) tool.

This release adds support for the next USB-SD-Mux generation, that is currently in development.
The internal hardware changes and the addition of user-controllable output pins necessitate changes to the control software.

I've removed the `+git${SRCPV}` part from the `PV`, as the commit hash matches the 0.3.0 release tag.