### PR TITLE
Split and Update labgrid Recipe (master / v23.0.5)

### DIFF
--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -1,0 +1,51 @@
+DESCRIPTION = "Embedded systems control library for development, testing and installation"
+HOMEPAGE = "https://github.com/labgrid-project"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c0e9407a08421b8c72f578433434f0bd"
+
+RDEPENDS:${PN} = " \
+    coreutils \
+    ser2net \
+    libgpiod \
+    python3-ansicolors \
+    python3-attrs \
+    python3-asyncio \
+    python3-autobahn \
+    python3-jinja2 \
+    python3-multiprocessing \
+    python3-pexpect \
+    python3-pyserial \
+    python3-pytest \
+    python3-pyudev \
+    python3-pyusb \
+    python3-pyyaml \
+    python3-requests \
+    python3-xmodem \
+    python3-graphviz \
+"
+
+SRC_URI = " \
+    file://configuration.yaml \
+    file://labgrid-exporter.service \
+    file://environment \
+    "
+
+SRCREV = "ba15037ff7fb2cd0748aa404c6cf6dcff6c3b143"
+S = "${WORKDIR}/git"
+
+DEPENDS += "python3-setuptools-scm-native"
+DEPENDS += "python3-pytest-runner-native"
+
+inherit python_setuptools_build_meta systemd
+
+SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/labgrid
+    install -m 0644 ${WORKDIR}/configuration.yaml ${D}${sysconfdir}/labgrid
+    install -m 0644 ${WORKDIR}/environment ${D}${sysconfdir}/labgrid
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/labgrid-exporter.service ${D}${systemd_system_unitdir}/
+}
+
+FILES:${PN} += "${sysconfdir} ${systemd_system_unitdir}"

--- a/recipes-devtools/python/python3-labgrid_23.0.2.bb
+++ b/recipes-devtools/python/python3-labgrid_23.0.2.bb
@@ -1,0 +1,5 @@
+require python3-labgrid.inc
+
+SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0"
+
+SRCREV = "ba15037ff7fb2cd0748aa404c6cf6dcff6c3b143"

--- a/recipes-devtools/python/python3-labgrid_23.0.5.bb
+++ b/recipes-devtools/python/python3-labgrid_23.0.5.bb
@@ -2,4 +2,4 @@ require python3-labgrid.inc
 
 SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0"
 
-SRCREV = "ba15037ff7fb2cd0748aa404c6cf6dcff6c3b143"
+SRCREV = "7a63be1682f174ff29584bf178c3fa077c582dcb"

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -4,6 +4,8 @@ SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=s
 
 SRCREV = "ba15037ff7fb2cd0748aa404c6cf6dcff6c3b143"
 
+PV = "23.0.2+git"
+
 LABGRID_USE_DEVEL_VERSION[doc] = "Global switch to enable labgrid development (git) version"
 LABGRID_USE_DEVEL_VERSION ??= "-1"
 DEFAULT_PREFERENCE ??= "${LABGRID_USE_DEVEL_VERSION}"

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -1,10 +1,10 @@
 require python3-labgrid.inc
 
-SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0"
+SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=master"
 
-SRCREV = "ba15037ff7fb2cd0748aa404c6cf6dcff6c3b143"
+SRCREV = "91c7e9cb044e1227f657a0db983d48c857c21b16"
 
-PV = "23.0.2+git"
+PV = "23+git"
 
 LABGRID_USE_DEVEL_VERSION[doc] = "Global switch to enable labgrid development (git) version"
 LABGRID_USE_DEVEL_VERSION ??= "-1"

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -1,52 +1,9 @@
-DESCRIPTION = "Embedded systems control library for development, testing and installation"
-HOMEPAGE = "https://github.com/labgrid-project"
-LICENSE = "LGPL-2.1-or-later"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=c0e9407a08421b8c72f578433434f0bd"
+require python3-labgrid.inc
 
-RDEPENDS:${PN} = " \
-    coreutils \
-    ser2net \
-    libgpiod \
-    python3-ansicolors \
-    python3-attrs \
-    python3-asyncio \
-    python3-autobahn \
-    python3-jinja2 \
-    python3-multiprocessing \
-    python3-pexpect \
-    python3-pyserial \
-    python3-pytest \
-    python3-pyudev \
-    python3-pyusb \
-    python3-pyyaml \
-    python3-requests \
-    python3-xmodem \
-    python3-graphviz \
-"
-
-SRC_URI = " \
-    git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0 \
-    file://configuration.yaml \
-    file://labgrid-exporter.service \
-    file://environment \
-    "
+SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0"
 
 SRCREV = "ba15037ff7fb2cd0748aa404c6cf6dcff6c3b143"
-S = "${WORKDIR}/git"
 
-DEPENDS += "python3-setuptools-scm-native"
-DEPENDS += "python3-pytest-runner-native"
-
-inherit python_setuptools_build_meta systemd
-
-SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
-
-do_install:append() {
-    install -d ${D}${sysconfdir}/labgrid
-    install -m 0644 ${WORKDIR}/configuration.yaml ${D}${sysconfdir}/labgrid
-    install -m 0644 ${WORKDIR}/environment ${D}${sysconfdir}/labgrid
-    install -d ${D}${systemd_system_unitdir}
-    install -m 0644 ${WORKDIR}/labgrid-exporter.service ${D}${systemd_system_unitdir}/
-}
-
-FILES:${PN} += "${sysconfdir} ${systemd_system_unitdir}"
+LABGRID_USE_DEVEL_VERSION[doc] = "Global switch to enable labgrid development (git) version"
+LABGRID_USE_DEVEL_VERSION ??= "-1"
+DEFAULT_PREFERENCE ??= "${LABGRID_USE_DEVEL_VERSION}"


### PR DESCRIPTION
Splits up the recipe into a master/development and a release variant.

Bumps both recipes afterward.