### PR TITLE
python3-lxa-iobus: update to version 0.5.1

### DIFF
--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -15,14 +15,14 @@ SRC_URI = " \
     file://environment \
     "
 
-PV = "0.4.2+git${SRCPV}"
-SRCREV = "af8ff293e9867dc4444ee354c06c7f8bcac410a7"
+PV = "0.5.0+git${SRCPV}"
+SRCREV = "c1a56a5e5b5b3a7a6d4248892779a8812ce44fb4"
 
 S = "${WORKDIR}/git"
 
 DEPENDS += "python3-setuptools-scm-native"
 
-inherit setuptools3 systemd
+inherit python_setuptools_build_meta systemd
 
 do_install:append() {
     # CAN interface setup is handled by systemd service instead of this script

--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -15,8 +15,8 @@ SRC_URI = " \
     file://environment \
     "
 
-PV = "0.5.0+git${SRCPV}"
-SRCREV = "c1a56a5e5b5b3a7a6d4248892779a8812ce44fb4"
+PV = "0.5.1+git${SRCPV}"
+SRCREV = "1d90a81eef5a61fd0d2bfdcd72a7a1e98cbf1290"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
From the version 0.5.0 release notes:

 - Fix "LICENSE" typo in setup.cfg
 - Expose individual node info via REST and allow CORS requests
 - Add formatters and linters to the CI and fix the fallout
 - lxa_iobus: move the project from setup.py to pyproject.toml
 - Cleanups, code deduplication, improvements and maintenance
 - lxa_iobus: node: add HTTP API based LxaRemoteNode
 - Add support for the LXA Optick latency measurement util
 - lxa_iobus: firmware: update Ethernet Mux and 4DO-3DI-3AI firmware to 0.6.0
 - README: Update DCO to follow the kernel wording

The change away from setup.py to a fully pyproject.toml based build workflow meant that we had to adapt the inherited python class.

The iobus server package also includes the new `optick` commandline utility to control LXA Optick latency measurement hardware.

TODO before merging:

- [x] The CI job fails due to a changed poky LAYERSERIES_COMPAT. PR #50 should be merged first and this PR be rebased on top of it to fix the broken CI.