### PR TITLE
layer.conf: add 'scarthgap' to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "mickledore nanbield"
+LAYERSERIES_COMPAT_labgrid = "nanbield"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "nanbield"
+LAYERSERIES_COMPAT_labgrid = "nanbield scarthgap"


### PR DESCRIPTION
Recently CI jobs have started [failing](https://github.com/labgrid-project/meta-labgrid/actions/runs/8570392864/job/23488216369?pr=49) since poky master has changed its LAYERSERIES_COMPAT to scarthgap.

Add scarthgap compatibility and while at it remove mickledore, which has reach its EOL.