### PR TITLE
recipes: follow WORKDIR -> UNPACKDIR transition

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "nanbield scarthgap"
+LAYERSERIES_COMPAT_labgrid = "styhead"

--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -42,10 +42,10 @@ SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
 
 do_install:append() {
     install -d ${D}${sysconfdir}/labgrid
-    install -m 0644 ${WORKDIR}/configuration.yaml ${D}${sysconfdir}/labgrid
-    install -m 0644 ${WORKDIR}/environment ${D}${sysconfdir}/labgrid
+    install -m 0644 ${UNPACKDIR}/configuration.yaml ${D}${sysconfdir}/labgrid
+    install -m 0644 ${UNPACKDIR}/environment ${D}${sysconfdir}/labgrid
     install -d ${D}${systemd_system_unitdir}
-    install -m 0644 ${WORKDIR}/labgrid-exporter.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${UNPACKDIR}/labgrid-exporter.service ${D}${systemd_system_unitdir}/
 }
 
 FILES:${PN} += "${sysconfdir} ${systemd_system_unitdir}"

--- a/recipes-devtools/python/python3-lxa-iobus_git.bb
+++ b/recipes-devtools/python/python3-lxa-iobus_git.bb
@@ -27,7 +27,7 @@ inherit python_setuptools_build_meta systemd
 do_install:append() {
     # CAN interface setup is handled by systemd service instead of this script
     rm -f ${D}${bindir}/lxa-iobus-can-setup
-    install -D -m0644 ${WORKDIR}/environment ${D}${sysconfdir}/lxa-iobus/environment
+    install -D -m0644 ${UNPACKDIR}/environment ${D}${sysconfdir}/lxa-iobus/environment
     install -D -m0644 ${S}/contrib/systemd/lxa-iobus.service ${D}${systemd_system_unitdir}/lxa-iobus.service
 }
 

--- a/recipes-devtools/python/python3-powerrelay_git.bb
+++ b/recipes-devtools/python/python3-powerrelay_git.bb
@@ -30,7 +30,7 @@ SYSTEMD_SERVICE:${PN} = "labgrid-powerrelay.service"
 do_install:append() {
     rm -rf "${D}${datadir}"
     install -d ${D}${systemd_system_unitdir}
-    install -m 0644 ${WORKDIR}/labgrid-powerrelay.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${UNPACKDIR}/labgrid-powerrelay.service ${D}${systemd_system_unitdir}/
 }
 
 FILES:${PN} += "${systemd_system_unitdir}"


### PR DESCRIPTION
This adapts to the oe-core rework to enforce a separate directory for unpacking local sources (`UNPACKDIR`) instead of polluting `WORKDIR` directly.

Follows the preliminary guideline from:
https://lists.openembedded.org/g/openembedded-architecture/message/2007

For this, we need to break compatibility with all releases before `master`/`styhead`.