### PR TITLE
python3-labgrid: use a SRCBRANCH variable in the git URL

### DIFF
--- a/recipes-devtools/python/python3-labgrid_23.0.5.bb
+++ b/recipes-devtools/python/python3-labgrid_23.0.5.bb
@@ -1,5 +1,6 @@
 require python3-labgrid.inc
 
-SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=stable-23.0"
+SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=${SRCBRANCH}"
 
+SRCBRANCH = "stable-23.0"
 SRCREV = "7a63be1682f174ff29584bf178c3fa077c582dcb"

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -1,7 +1,8 @@
 require python3-labgrid.inc
 
-SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=master"
+SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=${SRCBRANCH}"
 
+SRCBRANCH = "master"
 SRCREV = "91c7e9cb044e1227f657a0db983d48c857c21b16"
 
 PV = "23+git"


### PR DESCRIPTION
This makes it easier to switch the branch together with the SRCREV using .bbappend or .conf files.

This is a backport of #52.