### PR TITLE
python3-usbmux: also follow WORKDIR -> UNPACKDIR transition

### DIFF
--- a/recipes-devtools/python/python3-usbmuxctl_0.1.3.bb
+++ b/recipes-devtools/python/python3-usbmuxctl_0.1.3.bb
@@ -19,7 +19,7 @@ RDEPENDS:${PN} = " \
 inherit setuptools3 pypi
 
 do_install:append() {
-    install -D -m0644 ${WORKDIR}/99-usbmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbmux.rules
+    install -D -m0644 ${UNPACKDIR}/99-usbmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbmux.rules
 }
 
 FILES:${PN} += "${sysconfdir}"


### PR DESCRIPTION
This adapts to the oe-core rework to enforce a separate directory for unpacking local sources (`UNPACKDIR`) instead of polluting `WORKDIR` directly.

The other recipes have already been transitioned in  commit 40f8f6f ("recipes: follow WORKDIR -> UNPACKDIR transition"), but this one seems to have been left out.

This should fix the CI build errors we see on master and in #54.