### PR TITLE
CI: Run scheduled jobs via workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
   pull_request: {}
   # allow rebuilding without a push
   workflow_dispatch: {}
-  # pre-build sstate regularly
-  schedule:
-    - cron: '30 2 * * *'
 
 jobs:
   build:

--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -1,0 +1,21 @@
+name: Schedule Builds
+
+on:
+  # allow rebuilding manually
+  workflow_dispatch:
+  # pre-build sstate regularly
+  schedule:
+    - cron: '30 2 * * *'
+
+jobs:
+  build:
+    name: Schedule Builds
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Trigger master build
+        run: gh workflow run build --ref master

--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -19,3 +19,6 @@ jobs:
 
       - name: Trigger master build
         run: gh workflow run build --ref master
+
+      - name: Trigger scarthgap build
+        run: gh workflow run build --ref scarthgap

--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Trigger scarthgap build
         run: gh workflow run build --ref scarthgap
+
+      - name: Trigger kirkstone build
+        run: gh workflow run build --ref kirkstone

--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Schedule Builds
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.SCHEDULE_BUILDS }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
We currently only test the master branch on a regular schedule and not the different release branches (like e.g. scarthgap).

Also testing these other branches is complicated by the following detail in the GitHub action [documentation][1]:

> Scheduled workflows will only run on the default branch

This means we need some sort of workaround to run scheduled jobs on different branches. This commit adds a scheduled job on the master branch to trigger jobs on other branches via the `workflow_dispatch` event.

[1]: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule

TODO before merging:

- [x] Update the scarthgap build job to match the master build job (run on self-hosted runner and allow `workflow_dispatch`)¹.
- [x] Update the kirkstone build job to match the master build job (run on self-hosted runner and allow `workflow_dispatch`)¹.
- [x] Set the `SCHEDULE_BUILDS` variable to a true-ish value.

---

¹ The `git clone` commands for poky and other meta-layers need to be adapted.