### PR TITLE
CI: Sync the CI config from master to the kirkstone branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           sudo apt-get install diffstat chrpath
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: meta-labgrid
       - name: Clone poky

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           path: meta-labgrid
       - name: Clone poky
-        run: git clone -b kirkstone git://git.yoctoproject.org/poky
+        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b kirkstone https://github.com/yoctoproject/poky.git
       - name: Clone meta-openembedded
-        run: git clone -b kirkstone https://github.com/openembedded/meta-openembedded.git
+        run: git clone --shared --reference-if-able /srv/shared-git/meta-openembedded.git -b kirkstone https://github.com/openembedded/meta-openembedded.git
       - name: Initialize build directory
         run: |
           source poky/oe-init-build-env build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get -q -y --no-install-recommends install diffstat chrpath
+          sudo apt-get -q -y --no-install-recommends install diffstat chrpath python3-distutils
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: meta-labgrid CI
+name: build
 
 on:
   push: {}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,15 @@ on:
 jobs:
   build:
     name: meta-labgrid Build
-    runs-on: ubuntu-22.04
-    timeout-minutes: 720
+    # run on self-hosted runner for the main repo or if vars.BUILD_RUNS_ON is set
+    runs-on: >-
+      ${{
+        (vars.BUILD_RUNS_ON != ''  && fromJSON(vars.BUILD_RUNS_ON)) ||
+        (github.repository == 'labgrid-project/meta-labgrid' && fromJSON('["self-hosted", "forrest", "build"]')) ||
+        'ubuntu-22.04'
+      }}
+    # abort if it seems that we're rebuilding too much
+    timeout-minutes: 120
     steps:
       - name: Install required packages
         run: |
@@ -29,9 +36,16 @@ jobs:
           bitbake-layers add-layer ../meta-openembedded/meta-oe
           bitbake-layers add-layer ../meta-openembedded/meta-python
           bitbake-layers add-layer ../meta-labgrid
-          echo 'INHERIT += "rm_work"' >> conf/local.conf
+          if [ -f ~/.yocto/auto.conf ]; then
+            cp ~/.yocto/auto.conf conf/
+          else
+            echo 'SSTATE_MIRRORS = "file://.* https://github-runner.pengutronix.de/sstate-cache/PATH"' >> conf/auto.conf
+            echo 'BB_SIGNATURE_HANDLER = "OEBasicHash"' >> conf/auto.conf
+            echo 'BB_HASHSERVE = ""' >> conf/auto.conf
+            echo 'OPKGBUILDCMD = "opkg-build -Z gzip -a -1n"' >> conf/auto.conf
+            echo 'INHERIT += "rm_work"' >> conf/auto.conf
+          fi
           echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
-          echo 'SSTATE_MIRRORS = "file://.* http://195.201.147.117/sstate-cache/PATH"' >> conf/local.conf
       - name: Build autobahn
         run: |
           source poky/oe-init-build-env build
@@ -44,3 +58,13 @@ jobs:
         run: |
           source poky/oe-init-build-env build
           bitbake python3-pyserial sispmctl
+      - name: Cache Data
+        env:
+          CACHE_KEY: ${{ secrets.YOCTO_CACHE_KEY }}
+        if: ${{ env.CACHE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$CACHE_KEY" >> ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          rsync -rvx --ignore-existing build/downloads yocto-cache: || true
+          rsync -rvx --ignore-existing build/sstate-cache yocto-cache: || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get install diffstat chrpath
+          sudo apt-get -q -y --no-install-recommends install diffstat chrpath
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -1,14 +1,9 @@
 name: meta-labgrid CI
 
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  push: {}
+  pull_request: {}
+
 jobs:
   build:
     name: meta-labgrid Build
@@ -23,9 +18,9 @@ jobs:
         with:
           path: meta-labgrid
       - name: Clone poky
-        run: git clone -b master git://git.yoctoproject.org/poky
+        run: git clone -b kirkstone git://git.yoctoproject.org/poky
       - name: Clone meta-openembedded
-        run: git clone -b master https://github.com/openembedded/meta-openembedded.git
+        run: git clone -b kirkstone https://github.com/openembedded/meta-openembedded.git
       - name: Initialize build directory
         run: |
           source poky/oe-init-build-env build

--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -3,6 +3,8 @@ name: meta-labgrid CI
 on:
   push: {}
   pull_request: {}
+  # allow rebuilding without a push
+  workflow_dispatch: {}
 
 jobs:
   build:

--- a/.github/workflows/meta-labgrid.yml
+++ b/.github/workflows/meta-labgrid.yml
@@ -12,12 +12,12 @@ on:
 jobs:
   build:
     name: meta-labgrid Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 720
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get install diffstat
+          sudo apt-get install diffstat chrpath
       - name: Checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This is a collection of cherry picked commits and new commits to sync the build job from `master` to the `kirkstone` branch.
The intended use is to allow periodic branch for the kirkstone branch via #57.