### PR TITLE
python3-labgrid: Add new package for coordinator

### DIFF
--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -48,7 +48,7 @@ DEPENDS += "python3-pytest-runner-native"
 inherit python_setuptools_build_meta systemd
 
 SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
-SYSTEMD_SERVICE:${PN} = "labgrid-coordinator.service"
+SYSTEMD_SERVICE:${PN}-coordinator = "labgrid-coordinator.service"
 
 # Client/library access to the device via SSH as "root" user is assumed.
 # Additional configuration (dedicated user and related sudoers config for
@@ -66,4 +66,8 @@ do_install:append() {
     install -m 0644 ${UNPACKDIR}/labgrid-coordinator.service ${D}${systemd_system_unitdir}/
 }
 
+PACKAGES += "${PN}-coordinator"
+RDEPENDS:${PN}-coordinator = "${PN}"
+
+FILES:${PN}-coordinator += "${systemd_system_unitdir}/labgrid-coordinator.service /usr/bin/labgrid-coordinator"
 FILES:${PN} += "${sysconfdir} ${systemd_system_unitdir}"

--- a/recipes-devtools/python/python3-labgrid/environment
+++ b/recipes-devtools/python/python3-labgrid/environment
@@ -3,3 +3,8 @@
 
 LABGRID_COORDINATOR_IP=127.0.0.1
 LABGRID_COORDINATOR_PORT=20408
+
+### The coordinator service will listen to the following ip, if the service is also
+### enabled.
+
+LABGRID_COORDINATOR_LISTEN_IP=0.0.0.0

--- a/recipes-devtools/python/python3-labgrid/labgrid-coordinator.service
+++ b/recipes-devtools/python/python3-labgrid/labgrid-coordinator.service
@@ -4,7 +4,10 @@ After=network.target
 
 [Service]
 Environment="PYTHONUNBUFFERED=1"
-ExecStart=/usr/bin/labgrid-coordinator
+Environment="LABGRID_COORDINATOR_LISTEN_IP=0.0.0.0"
+Environment="LABGRID_COORDINATOR_PORT=20408"
+EnvironmentFile=/etc/labgrid/environment
+ExecStart=/usr/bin/labgrid-coordinator -l ${LABGRID_COORDINATOR_LISTEN_IP}:${LABGRID_COORDINATOR_PORT}
 Restart=on-failure
 DynamicUser=yes
 StateDirectory=labgrid-coordinator


### PR DESCRIPTION
Some devices might also want to start the labgrid-coordinator as a systemd service. but this should not be the default. Move the labgrid-coordinator to a new package, that depends on labgrid.