### PR TITLE
Add tools and helpers for remote usage

### DIFF
--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -26,6 +26,13 @@ RDEPENDS:${PN} = " \
     ser2net \
 "
 
+RRECOMMENDS:${PN} = " \
+    ethtool \
+    iproute2-ip \
+    rsync \
+    socat \
+"
+
 SRC_URI = " \
     file://configuration.yaml \
     file://labgrid-exporter.service \

--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -24,6 +24,7 @@ RDEPENDS:${PN} = " \
     python3-requests \
     python3-xmodem \
     ser2net \
+    sudo \
 "
 
 RRECOMMENDS:${PN} = " \
@@ -35,6 +36,7 @@ RRECOMMENDS:${PN} = " \
 
 SRC_URI = " \
     file://configuration.yaml \
+    file://helpers.yaml \
     file://labgrid-exporter.service \
     file://environment \
     "
@@ -46,9 +48,16 @@ inherit python_setuptools_build_meta systemd
 
 SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
 
+# Client/library access to the device via SSH as "root" user is assumed.
+# Additional configuration (dedicated user and related sudoers config for
+# password-less helpers usage) shall be done separately.
 do_install:append() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/helpers/labgrid-* ${D}${sbindir}
+
     install -d ${D}${sysconfdir}/labgrid
     install -m 0644 ${UNPACKDIR}/configuration.yaml ${D}${sysconfdir}/labgrid
+    install -m 0644 ${UNPACKDIR}/helpers.yaml ${D}${sysconfdir}/labgrid
     install -m 0644 ${UNPACKDIR}/environment ${D}${sysconfdir}/labgrid
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/labgrid-exporter.service ${D}${systemd_system_unitdir}/

--- a/recipes-devtools/python/python3-labgrid/helpers.yaml
+++ b/recipes-devtools/python/python3-labgrid/helpers.yaml
@@ -1,0 +1,8 @@
+### This is an example labgrid helpers. This file will be installed to
+### /etc/labgrid/helpers.yaml and read by helpers that need a configuration.
+
+## Configuration for labgrid-raw-interface; under denied-interfaces a list of
+## interfaces that shall not be touched by labgrid can be specified.
+#raw-interface:
+#  denied-interfaces:
+#    - 'eth1'


### PR DESCRIPTION
Add tools and helpers which are used by labgrid when used though an exporter.

Since they are not hard dependencies, tools are added to RRECOMMENDS rather than RDEPENDS.
