### PR TITLE
Recipe Version Bumps

### DIFF
--- a/recipes-devtools/python/python3-labgrid_25.0.1.bb
+++ b/recipes-devtools/python/python3-labgrid_25.0.1.bb
@@ -3,4 +3,4 @@ require python3-labgrid.inc
 SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=${SRCBRANCH}"
 
 SRCBRANCH = "stable-25.0"
-SRCREV = "6d8febb7263f772bb5d0b4aed85f268f7968412e"
+SRCREV = "4b2f81389386454a0eb84e361e776ea818ffb038"

--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -3,7 +3,7 @@ require python3-labgrid.inc
 SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=${SRCBRANCH}"
 
 SRCBRANCH = "master"
-SRCREV = "6d8febb7263f772bb5d0b4aed85f268f7968412e"
+SRCREV = "4398da7728675bc1a594284d75785590fb496660"
 
 PV = "25.0+git"
 

--- a/recipes-devtools/python/python3-usbmuxctl/99-usbmux.rules
+++ b/recipes-devtools/python/python3-usbmuxctl/99-usbmux.rules
@@ -1,2 +1,0 @@
-# Linux Automation GmbH USB-Mux
-ATTRS{idVendor}=="33f7", ATTRS{idProduct}=="0001", TAG+="uaccess", GROUP="plugdev"

--- a/recipes-devtools/python/python3-usbmuxctl_0.1.4.bb
+++ b/recipes-devtools/python/python3-usbmuxctl_0.1.4.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/linux-automation/usbmuxctl"
 LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI[sha256sum] = "b7a9c7bf0645e0d2026fc63307a6724c24be6a33961f0f65cc313be7c8d45feb"
+SRC_URI[sha256sum] = "f200647bd72ea5b5a77d6d9e1f0641e2aae1da37fc2317a2f73929b034388845"
 
 SRC_URI += " \
     file://99-usbmux.rules \
@@ -16,7 +16,7 @@ RDEPENDS:${PN} = " \
     python3-termcolor \
 "
 
-inherit setuptools3 pypi
+inherit python_setuptools_build_meta pypi
 
 do_install:append() {
     install -D -m0644 ${UNPACKDIR}/99-usbmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbmux.rules

--- a/recipes-devtools/python/python3-usbmuxctl_0.1.4.bb
+++ b/recipes-devtools/python/python3-usbmuxctl_0.1.4.bb
@@ -5,10 +5,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI[sha256sum] = "f200647bd72ea5b5a77d6d9e1f0641e2aae1da37fc2317a2f73929b034388845"
 
-SRC_URI += " \
-    file://99-usbmux.rules \
-    "
-
 DEPENDS += "python3-setuptools-scm-native"
 
 RDEPENDS:${PN} = " \
@@ -19,7 +15,7 @@ RDEPENDS:${PN} = " \
 inherit python_setuptools_build_meta pypi
 
 do_install:append() {
-    install -D -m0644 ${UNPACKDIR}/99-usbmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbmux.rules
+    install -D -m0644 ${S}/contrib/udev/99-usbmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbmux.rules
 }
 
 FILES:${PN} += "${sysconfdir}"

--- a/recipes-devtools/python/python3-usbsdmux_24.11.1.bb
+++ b/recipes-devtools/python/python3-usbsdmux_24.11.1.bb
@@ -7,11 +7,11 @@ SRC_URI = " \
     git://github.com/linux-automation/usbsdmux.git;protocol=https;branch=master \
     "
 
-SRCREV = "89e93df939a19bab0fa980e914ed39f33afa2785"
+SRCREV = "051f3816aea89623aaa24b6720e92442f03e2f76"
 
 DEPENDS += "python3-setuptools-scm-native"
 
-inherit setuptools3
+inherit python_setuptools_build_meta
 
 do_install:append() {
     install -D -m0644 ${S}/contrib/udev/99-usbsdmux.rules ${D}${sysconfdir}/udev/rules.d/99-usbsdmux.rules

--- a/recipes-devtools/sispmctl/sispmctl_4.12.bb
+++ b/recipes-devtools/sispmctl/sispmctl_4.12.bb
@@ -10,4 +10,4 @@ PACKAGECONFIG[web] = "--disable-webless,--enable-webless,"
 
 SRC_URI = "https://sourceforge.net/projects/sispmctl/files/sispmctl/sispmctl-${PV}/sispmctl-${PV}.tar.gz"
 
-SRC_URI[sha256sum] = "74b94a3710046b15070c7311f0cacb81554c86b4227719cc2733cb96c7052578"
+SRC_URI[sha256sum] = "e757863a4838da6e1ca72a57adc5aca6fc47ffbddc72a69052d8abd743d57082"


### PR DESCRIPTION
* `sispmctl`: bump to 4.12
* `python3-usbmuxctl`: use udev rule from upstream
* `python3-usbmuxctl`: bump to 0.1.4
* `python3-usbsdmux`: bump to 24.01.1
* `python3-labgrid`: bump git version to 4398da7
* `python3-labgrid`: bump to 25.0.1
