### PR TITLE
ci: schedule walnascar builds and add badges to README

### DIFF
--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -22,6 +22,9 @@ jobs:
         run: gh workflow run build --ref master
 
       - name: Trigger scarthgap build
+        run: gh workflow run build --ref walnascar
+
+      - name: Trigger scarthgap build
         run: gh workflow run build --ref scarthgap
 
       - name: Trigger kirkstone build

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,15 @@
+.. list-table::
+   :header-rows: 1
+
+   * - master
+     - walnascar
+     - scarthgap
+     - kirkstone
+   * - |gh_master|
+     - |gh_walnascar|
+     - |gh_scarthgap|
+     - |gh_kirkstone|
+
 |MIT| |Matrix|
 
 The meta-labgrid layer provides support for integrating the labgrid exporter
@@ -82,3 +94,11 @@ IV. References
    :target: https://raw.githubusercontent.com/labgrid-project/meta-labgrid/master/COPYING.MIT
 .. |Matrix| image:: https://img.shields.io/matrix/labgrid:matrix.org?label=matrix%20chat
    :target: https://app.element.io/#/room/#labgrid:matrix.org
+.. |gh_kirkstone| image:: https://github.com/labgrid-project/meta-labgrid/actions/workflows/build.yml/badge.svg?branch=kirkstone&event=workflow_dispatch
+   :target: https://github.com/labgrid-project/meta-labgrid/actions?query=event%3Aworkflow_dispatch+branch%3Akirkstone++
+.. |gh_scarthgap| image:: https://github.com/labgrid-project/meta-labgrid/actions/workflows/build.yml/badge.svg?branch=scarthgap&event=workflow_dispatch
+   :target: https://github.com/labgrid-project/meta-labgrid/actions?query=event%3Aworkflow_dispatch+branch%3Ascarthgap++
+.. |gh_walnascar| image:: https://github.com/labgrid-project/meta-labgrid/actions/workflows/build.yml/badge.svg?branch=walnascar&event=workflow_dispatch
+   :target: https://github.com/labgrid-project/meta-labgrid/actions?query=event%3Aworkflow_dispatch+branch%3Awalnascar++
+.. |gh_master| image:: https://github.com/labgrid-project/meta-labgrid/actions/workflows/build.yml/badge.svg?branch=master&event=workflow_dispatch
+   :target: https://github.com/labgrid-project/meta-labgrid/actions?query=event%3Aworkflow_dispatch+branch%3Amaster++


### PR DESCRIPTION
We have a walnascar branch for some time now, which is even actively used in [linux-automation/meta-lxatac](https://github.com/linux-automation/meta-lxatac), but we somehow forgot to add it to the scheduled builds.

While fixing that I also noticed that we do not display the build status like we do for other projects.
Also address that by copying a README snippet from [rauc/meta-rauc](https://github.com/rauc/meta-rauc).