### PR TITLE
layer.conf: remove 'walnascar' from LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "walnascar whinlatter"
+LAYERSERIES_COMPAT_labgrid = "whinlatter"


### PR DESCRIPTION
Commit 41f16ed ("remove S = "${WORKDIR}/git"") makes the master branch of meta-labgrid incompatible with the walnascar release, since `S` is not set to the correct directory by default.

Remove it from the list of compatible layers.