### PR TITLE
python3-labgrid: bump git version to f63dfd7

### DIFF
--- a/recipes-devtools/python/python3-labgrid_git.bb
+++ b/recipes-devtools/python/python3-labgrid_git.bb
@@ -3,7 +3,7 @@ require python3-labgrid.inc
 SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=${SRCBRANCH}"
 
 SRCBRANCH = "master"
-SRCREV = "bf387497f73b8bd1bc6a35b52a5c7443468ff21f"
+SRCREV = "f63dfd70a5da2c7007ee8c320fa969df2c0bf16e"
 
 PV = "25.0+git"
 


### PR DESCRIPTION
Hi,

I have decided to keep the update script from https://github.com/labgrid-project/meta-labgrid/pull/74 alive in my fork and manually backport its updates from time to time. In this case https://github.com/hnez/meta-labgrid/pull/8, which just updates the labgrid package by two commits.

----

This fixes an intermittent issue when using the SDWire: https://github.com/labgrid-project/labgrid/pull/1754.