### PR TITLE
python3-labgrid: Add a service file for labgrid-coordinator.

### DIFF
--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -38,6 +38,7 @@ SRC_URI = " \
     file://configuration.yaml \
     file://helpers.yaml \
     file://labgrid-exporter.service \
+    file://labgrid-coordinator.service \
     file://environment \
     "
 
@@ -47,6 +48,7 @@ DEPENDS += "python3-pytest-runner-native"
 inherit python_setuptools_build_meta systemd
 
 SYSTEMD_SERVICE:${PN} = "labgrid-exporter.service"
+SYSTEMD_SERVICE:${PN} = "labgrid-coordinator.service"
 
 # Client/library access to the device via SSH as "root" user is assumed.
 # Additional configuration (dedicated user and related sudoers config for
@@ -61,6 +63,7 @@ do_install:append() {
     install -m 0644 ${UNPACKDIR}/environment ${D}${sysconfdir}/labgrid
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/labgrid-exporter.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${UNPACKDIR}/labgrid-coordinator.service ${D}${systemd_system_unitdir}/
 }
 
 FILES:${PN} += "${sysconfdir} ${systemd_system_unitdir}"

--- a/recipes-devtools/python/python3-labgrid/labgrid-coordinator.service
+++ b/recipes-devtools/python/python3-labgrid/labgrid-coordinator.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Labgrid Coordinator
+After=network.target
+
+[Service]
+Environment="PYTHONUNBUFFERED=1"
+ExecStart=/usr/bin/labgrid-coordinator
+Restart=on-failure
+DynamicUser=yes
+StateDirectory=labgrid-coordinator
+# Set WorkingDirectory to StateDirectory, this works in DynamicUser mode since symlinks are created
+WorkingDirectory=%S/labgrid-coordinator
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a basic systemd service file to start a coordinator.


(cherry picked from commit 82ae3acec0b8efe7f55f42035893cc49371a7f69)