### PR TITLE
python3-labgrid: exporter: allow passing args to systemd ExecStart

### DIFF
--- a/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
+++ b/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Environment="PYTHONUNBUFFERED=1"
 EnvironmentFile=/etc/labgrid/environment
-ExecStart=/usr/bin/labgrid-exporter --coordinator ${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT} /etc/labgrid/configuration.yaml
+ExecStart=/usr/bin/labgrid-exporter --coordinator ${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT} /etc/labgrid/configuration.yaml ${LABGRID_EXPORTER_ARGS}
 Restart=on-failure
 RestartForceExitStatus=100
 RestartSec=30


### PR DESCRIPTION
Allow configuring e.g. the exporter hostname from the environment file by adding ${LABGRID_EXPORTER_ARGS} to the ExecStart command line.

[jlu@pengutronix.de: change LABGRID_ARGS to LABGRID_EXPORTER_ARGS]