### PR TITLE
python3-grpcio-{channelz,reflection}: fix build issues due to moved license line.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build labgrid
         run: |
           source openembedded-core/oe-init-build-env build
-          bitbake python3-labgrid
+          bitbake python3-labgrid python3-grpcio-channelz python3-grpcio-reflection python3-pyserial
       - name: Build sispmctl
         run: |
           source openembedded-core/oe-init-build-env build
@@ -59,7 +59,7 @@ jobs:
       - name: Build lxa-iobus
         run: |
           source openembedded-core/oe-init-build-env build
-          bitbake python3-lxa-iobus
+          bitbake python3-lxa-iobus python3-aiohttp-json-rpc python3-janus
       - name: Build usbmuxctl
         run: |
           source openembedded-core/oe-init-build-env build

--- a/recipes-devtools/python/python3-grpcio-channelz_1.78.0.bb
+++ b/recipes-devtools/python/python3-grpcio-channelz_1.78.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.grpc.io/"
 SECTION = "devel/python"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=7145f7cdd263359b62d342a02f005515"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=6;endline=6;md5=0bcf70029ff7f40a132bf95381ee0b2d"
 
 PYPI_PACKAGE = "grpcio_channelz"
 

--- a/recipes-devtools/python/python3-grpcio-reflection_1.78.0.bb
+++ b/recipes-devtools/python/python3-grpcio-reflection_1.78.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.grpc.io/"
 SECTION = "devel/python"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=7145f7cdd263359b62d342a02f005515"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=6;endline=6;md5=0bcf70029ff7f40a132bf95381ee0b2d"
 
 PYPI_PACKAGE = "grpcio_reflection"
 


### PR DESCRIPTION
The `License-Expression: Apache-2.0` lines in these projects have moved two lines up, breaking the license check with the [following error](https://github.com/linux-automation/meta-lxatac/actions/runs/22184995799/job/64156118293?pr=337#step:3:10492):

```
…
NOTE: recipe python3-grpcio-channelz-1.78.0-r0: task do_populate_lic: Started
NOTE: recipe python3-grpcio-reflection-1.78.0-r0: task do_populate_lic: Started
ERROR: python3-grpcio-channelz-1.78.0-r0 do_populate_lic: QA Issue: python3-grpcio-channelz: The LIC_FILES_CHKSUM does not match for file://PKG-INFO;beginline=8;endline=8;md5=7145f7cdd263359b62d342a02f005515
python3-grpcio-channelz: The new md5 checksum is 8fd338a7c86e84d15fb83217e2288451
python3-grpcio-channelz: Here is the selected license text:
vvvvvvvvvvvvvvvvvvvvvvvvvvvv beginline=8 vvvvvvvvvvvvvvvvvvvvvvvvvvvvv
Project-URL: Documentation, https://grpc.github.io/grpc/python/grpc_channelz.html
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ endline=8 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3-grpcio-channelz: Check if the license information has changed in /home/runner/runner/_work/meta-lxatac/meta-lxatac/build/tmp/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/python3-grpcio-channelz/1.78.0/sources/grpcio_channelz-1.78.0/PKG-INFO (lines 8 through to 8) to verify that the LICENSE value "Apache-2.0" remains valid [license-checksum]
ERROR: python3-grpcio-reflection-1.78.0-r0 do_populate_lic: QA Issue: python3-grpcio-reflection: The LIC_FILES_CHKSUM does not match for file://PKG-INFO;beginline=8;endline=8;md5=7145f7cdd263359b62d342a02f005515
python3-grpcio-reflection: The new md5 checksum is c90acd055e62e1822fa35d956ccdf669
python3-grpcio-reflection: Here is the selected license text:
vvvvvvvvvvvvvvvvvvvvvvvvvvvv beginline=8 vvvvvvvvvvvvvvvvvvvvvvvvvvvvv
Project-URL: Documentation, https://grpc.github.io/grpc/python/grpc_reflection.html
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ endline=8 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```