### PR TITLE
python3-labgrid: prepend coordinator package instead of append

### DIFF
--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -66,7 +66,7 @@ do_install:append() {
     install -m 0644 ${UNPACKDIR}/labgrid-coordinator.service ${D}${systemd_system_unitdir}/
 }
 
-PACKAGES += "${PN}-coordinator"
+PACKAGES =+ "${PN}-coordinator"
 RDEPENDS:${PN}-coordinator = "${PN}"
 
 FILES:${PN}-coordinator += "${systemd_system_unitdir}/labgrid-coordinator.service /usr/bin/labgrid-coordinator"


### PR DESCRIPTION
Using prepend (=+) instead of append (+=) here results in the coordinator package being built first and thus the files in `FILES:${PN}-coordinator` being claimed for it instead of the python3-labgrid package.

Otherwise the python3-labgrid-coordinator package will be empty and the python3-labgrid package will contain the coordinator service file and "binary".

Fixes: 7335c8adbceecd9d19dc20a68020a0206731e6f9