### PR TITLE
layer.conf: add 'wrynose' to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_labgrid = "8"
 LAYERDEPENDS_labgrid = "core"
 LAYERDEPENDS_labgrid += "meta-python"
 
-LAYERSERIES_COMPAT_labgrid = "whinlatter"
+LAYERSERIES_COMPAT_labgrid = "whinlatter wrynose"


### PR DESCRIPTION
The openembedded-core layer has recently updated their `LAYERSERIES_COMPAT` on the master branch to wrynose, resulting in broken CI builds for us.

We do not have a dedicated whinlatter branch and don't really need it, since master and whinlatter are still compatible.
We thus do not want to just replace the whinlatter `LAYERSERIES_COMPAT` on master. Instead just have both (until there are any incompatible changes).