### PR TITLE
python3-labgrid: exporter: fix startup and argument passing

### DIFF
--- a/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
+++ b/recipes-devtools/python/python3-labgrid/labgrid-exporter.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Environment="PYTHONUNBUFFERED=1"
 EnvironmentFile=/etc/labgrid/environment
-ExecStart=/usr/bin/labgrid-exporter --coordinator ${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT} /etc/labgrid/configuration.yaml ${LABGRID_EXPORTER_ARGS}
+ExecStart=/usr/bin/labgrid-exporter --coordinator ${LABGRID_COORDINATOR_IP}:${LABGRID_COORDINATOR_PORT} $LABGRID_EXPORTER_ARGS /etc/labgrid/configuration.yaml
 Restart=on-failure
 RestartForceExitStatus=100
 RestartSec=30


### PR DESCRIPTION
systemd passes `${VAR}` as a single arguemnt, leading to argument parsing errors:
  `labgrid-exporter.service: Referenced but unset environment variable
  evaluates to an empty string: LABGRID_EXPORTER_ARGS`

When `LABGRID_EXPORTER_ARGS` is unset, `sys.argv` ends up as
  `['/usr/bin/labgrid-exporter', '--coordinator', 'labgrid:20408',
  '/etc/labgrid/configuration.yaml', '']`
which leads to
  ```
  usage: labgrid-exporter [-h] [-c HOST:PORT] [-n NAME] [--hostname HOSTNAME]
                          [--fqdn] [-d] [-i] [--pystuck] [--pystuck-port PORT]
                          RESOURCES
  labgrid-exporter: error: unrecognized arguments:
  ```

Fix this by using the appropriate syntax (`$LABGRID_EXPORTER_ARGS`). See [1] for more background on this:

>   Basic environment variable substitution is supported. Use `${FOO}` as
>   part of a word, or as a word of its own, on the command line, in which
>   case it will be erased and replaced by the exact value of the
>   environment variable (if any) including all whitespace it contains,
>   always resulting in exactly a single argument. Use `$FOO` as a
>   separate word on the command line, in which case it will be replaced
>   by the value of the environment variable split at whitespace,
>   resulting in zero or more arguments. For this type of expansion,
>   quotes are respected when splitting into words, and afterwards
>   removed.

Also move `$LABGRID_EXPORTER_ARGS` before the positional argument, as that better matches the expected location for options.

[1] https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines

Fixes: 80c400841acd ("python3-labgrid: exporter: allow passing args to systemd ExecStart")