### PR TITLE
python3-labgrid: Upgrade 25.0.1 -> 26.0

### DIFF
--- a/recipes-devtools/python/python3-labgrid/0001-remote-client-Drop-exceptiongroup.patch
+++ b/recipes-devtools/python/python3-labgrid/0001-remote-client-Drop-exceptiongroup.patch
@@ -1,0 +1,39 @@
+From 89a1ae9824b21e8ab6f2b095bd8a9c335a636088 Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Tue, 9 Jun 2026 10:07:19 +0300
+Subject: [PATCH] remote/client: Drop exceptiongroup
+
+Remove the following import line because Yocto release Wrynose provides
+and uses a newer Python version in which as per PEP 654 ExceptionGroup
+is a builtin:
+
+from exceptiongroup import ExceptionGroup
+
+Fixes:
+
+ModuleNotFoundError: No module named 'exceptiongroup'
+
+Upstream-Status: Inappropriate [oe-specific]
+
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ labgrid/remote/client.py | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/labgrid/remote/client.py b/labgrid/remote/client.py
+index 4d2eb0bf..679ccf06 100755
+--- a/labgrid/remote/client.py
++++ b/labgrid/remote/client.py
+@@ -29,9 +29,6 @@ from typing import Any, Dict
+ import attr
+ import grpc
+ 
+-# TODO: drop if Python >= 3.11 guaranteed
+-from exceptiongroup import ExceptionGroup  # pylint: disable=redefined-builtin
+-
+ from .common import (
+     ResourceEntry,
+     ResourceMatch,
+-- 
+2.43.0
+

--- a/recipes-devtools/python/python3-labgrid_25.0.1.bb
+++ b/recipes-devtools/python/python3-labgrid_25.0.1.bb
@@ -1,6 +1,0 @@
-require python3-labgrid.inc
-
-SRC_URI += "git://github.com/labgrid-project/labgrid.git;protocol=https;branch=${SRCBRANCH}"
-
-SRCBRANCH = "stable-25.0"
-SRCREV = "4b2f81389386454a0eb84e361e776ea818ffb038"

--- a/recipes-devtools/python/python3-labgrid_26.0.bb
+++ b/recipes-devtools/python/python3-labgrid_26.0.bb
@@ -1,0 +1,7 @@
+require python3-labgrid.inc
+
+inherit pypi
+
+SRC_URI[sha256sum] = "686695d3fa8c0ac0c9a6e6b42f9c8e9e92a9363c9d4945718e5fc21e431bd3d8"
+
+SRC_URI += "file://0001-remote-client-Drop-exceptiongroup.patch"


### PR DESCRIPTION
Upgrade labgrid from 25.0.1 to 26.0 with the following modifications:

- Use PyPI source to ensure the same code is built whether labgrid is installed via this layer or pip on desktop Linux distributions like Debian, Ubuntu, etc.
- Drop the import of exceptiongroup because Yocto release Wrynose provides provides and uses a newer Python version in which as per PEP 654 ExceptionGroup is a builtin.