### PR TITLE
python3-labgrid: add python3-wheel-native as explicit dependency

### DIFF
--- a/recipes-devtools/python/python3-labgrid.inc
+++ b/recipes-devtools/python/python3-labgrid.inc
@@ -44,6 +44,7 @@ SRC_URI = " \
 
 DEPENDS += "python3-setuptools-scm-native"
 DEPENDS += "python3-pytest-runner-native"
+DEPENDS += "python3-wheel-native"
 
 inherit python_setuptools_build_meta systemd
 


### PR DESCRIPTION
This is just #94 re-opened by me to see if it fixes the build.

@Bastian-Krause I think there were some discussions for a "proper" fix for this in labgrid. Should wer wait for those or just merge this as-is to fix the build?

---

The dependency was removed from the python setuptools3 class (and others) in oe-core [1].
Re-add it as explicit dependency since it's listed in labgrid's pyproject.toml.

[1] https://git.openembedded.org/openembedded-core/commit/?id=e546c697b7ed9df5114ee23ef0024d2ed4c888a1