### PR TITLE
.github/workflows: update GitHub action checkout to version 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get -q -y --no-install-recommends install diffstat chrpath
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: meta-labgrid
       - name: Clone bitbake

--- a/.github/workflows/schedule-builds.yml
+++ b/.github/workflows/schedule-builds.yml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Trigger master build
         run: gh workflow run build --ref master


### PR DESCRIPTION
This gets rid of Node.js 20 deprecation warnings for all of our build jobs.